### PR TITLE
fix: compiling the hashmap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Programs using karver might look something like:
 {-# LANGUAGE OverloadedStrings #-}
 
 import Text.Karver
+import Text.Karver.Types
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as H
 import Data.Text (Text)


### PR DESCRIPTION
tested with ghc 7.4.1

I am not sure importing the submodule Types from karver is the right thing to do, but however the example does not compile.
cabal reports that karver is correctly installed : 
$ cabal list karver
- karver
  Synopsis: A simple template engine, inspired by jinja2
  Default available version: 0.1.0
  Installed versions: 0.1.0
  License:  BSD3

regards,
